### PR TITLE
Add notify-send to dependencies list

### DIFF
--- a/utils/ocr
+++ b/utils/ocr
@@ -9,7 +9,7 @@ TEXT_FILE="/tmp/ocr.txt"
 IMAGE_FILE="/tmp/ocr.png"
 
 # Check if the needed dependencies are installed
-dependencies=(tesseract maim xclip)
+dependencies=(tesseract maim notify-send xclip)
 for dependency in "${dependencies[@]}"; do
     type -p "$dependency" &>/dev/null || {
         # The reason why we are sending the error as a notification is because


### PR DESCRIPTION
Hey, thank you for making this repo, you've got some really useful scripts in here that I've taken advantage of 

The `notify-send` package isn't installed by default on most linux
distros, so we should add it to the dependencies list
https://ss64.com/bash/notify-send.html

In any case, I ran into this issue while setting up a new computer, figured why not make a PR 